### PR TITLE
feature: Notify user on backend disconnection (frontend)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=https://localhost:8443/
+VITE_API_URL=https://localhost:8443
 VITE_WS_URL=wss://localhost:8443/

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
 VITE_API_URL=https://localhost:8443/
+VITE_WS_URL=wss://localhost:8443/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "react-icons": "5.3.0",
     "react-quill-new": "3.3.0",
     "react-router-dom": "6.25.1",
+    "socket.io-client": "^4.8.1",
     "sonner": "1.5.0",
     "tailwind-merge": "2.5.2",
     "tailwindcss-animate": "1.0.7"

--- a/frontend/src/components/ui/overlay.tsx
+++ b/frontend/src/components/ui/overlay.tsx
@@ -1,0 +1,42 @@
+import { t } from 'i18next';
+import { WifiOff } from 'lucide-react';
+import React from 'react';
+
+type ConnectionOverlayProps = {
+  isConnected: boolean;
+};
+
+export const ConnectionOverlay: React.FC<ConnectionOverlayProps> = ({
+  isConnected,
+}) => {
+  if (isConnected) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 pointer-events-auto">
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-md" />
+
+      <div className="absolute inset-0 flex items-center justify-center p-4">
+        <div
+          className={`
+            flex flex-col items-center gap-4 px-8 py-6 rounded-xl shadow-2xl border-2 max-w-sm w-full
+            bg-red-500 text-white border-red-600 transition-all ease-in-out animate-pulse duration-[4s]
+          `}
+        >
+          <WifiOff className="w-12 h-12" />
+          <div className="text-center space-y-2">
+            <h3 className="text-lg font-semibold">
+              {t('msg.reconnectingBackend')}
+            </h3>
+            <p className="text-sm opacity-90">
+              {t('msg.wrongContactingBackend')}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConnectionOverlay;

--- a/frontend/src/components/ui/overlay.tsx
+++ b/frontend/src/components/ui/overlay.tsx
@@ -1,22 +1,38 @@
 import { t } from 'i18next';
 import { WifiOff } from 'lucide-react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 type ConnectionOverlayProps = {
   isConnected: boolean;
+  connectionState: 'connecting' | 'connected' | 'disconnected';
 };
 
 export const ConnectionOverlay: React.FC<ConnectionOverlayProps> = ({
   isConnected,
+  connectionState,
 }) => {
-  if (isConnected) {
+  const [showOverlay, setShowOverlay] = useState(false);
+
+  // Doesn't show overlay during initial load
+  useEffect(() => {
+    if (connectionState === 'disconnected') {
+      const timer = setTimeout(() => {
+        setShowOverlay(true);
+      }, 1000);
+
+      return () => clearTimeout(timer);
+    } else if (connectionState === 'connected') {
+      setShowOverlay(false);
+    }
+  }, [connectionState]);
+
+  if (!showOverlay || isConnected) {
     return null;
   }
 
   return (
     <div className="fixed inset-0 z-50 pointer-events-auto">
       <div className="absolute inset-0 bg-black/30 backdrop-blur-md" />
-
       <div className="absolute inset-0 flex items-center justify-center p-4">
         <div
           className={`

--- a/frontend/src/hooks/WebSocketContext.tsx
+++ b/frontend/src/hooks/WebSocketContext.tsx
@@ -14,14 +14,12 @@ export const WebSocketContext = createContext<WebSocketContextType | undefined>(
 
 type WebSocketProviderProps = {
   children: ReactNode;
-  url?: string;
 };
 
 export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({
   children,
-  url,
 }) => {
-  const { socket, isConnected } = useWebSocket(url);
+  const { socket, isConnected } = useWebSocket();
   return (
     <WebSocketContext.Provider value={{ socket, isConnected }}>
       {children}

--- a/frontend/src/hooks/WebSocketContext.tsx
+++ b/frontend/src/hooks/WebSocketContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, ReactNode } from 'react';
+import { Socket } from 'socket.io-client';
+
+import { useWebSocket } from './useWebSocket';
+
+export type WebSocketContextType = {
+  socket: Socket | null;
+  isConnected: boolean;
+};
+
+export const WebSocketContext = createContext<WebSocketContextType | undefined>(
+  undefined,
+);
+
+type WebSocketProviderProps = {
+  children: ReactNode;
+  url?: string;
+};
+
+export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({
+  children,
+  url,
+}) => {
+  const { socket, isConnected } = useWebSocket(url);
+  return (
+    <WebSocketContext.Provider value={{ socket, isConnected }}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+};

--- a/frontend/src/hooks/WebSocketContext.tsx
+++ b/frontend/src/hooks/WebSocketContext.tsx
@@ -6,6 +6,7 @@ import { useWebSocket } from './useWebSocket';
 export type WebSocketContextType = {
   socket: Socket | null;
   isConnected: boolean;
+  connectionState: 'connecting' | 'connected' | 'disconnected';
 };
 
 export const WebSocketContext = createContext<WebSocketContextType | undefined>(
@@ -19,9 +20,10 @@ type WebSocketProviderProps = {
 export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({
   children,
 }) => {
-  const { socket, isConnected } = useWebSocket();
+  const { socket, isConnected, connectionState } = useWebSocket();
+
   return (
-    <WebSocketContext.Provider value={{ socket, isConnected }}>
+    <WebSocketContext.Provider value={{ socket, isConnected, connectionState }}>
       {children}
     </WebSocketContext.Provider>
   );

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+type UseWebSocketReturn = {
+  socket: Socket | null;
+  isConnected: boolean;
+};
+
+export const useWebSocket = (url?: string): UseWebSocketReturn => {
+  const [isConnected, setIsConnected] = useState(false);
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    // URL
+    const socketUrl = 'wss://localhost:8443';
+
+    // Websocket Connection
+    const socket = io(socketUrl, {
+      autoConnect: true,
+      reconnection: true,
+      reconnectionDelay: 5000,
+      reconnectionAttempts: Infinity,
+      reconnectionDelayMax: 10000,
+      timeout: 5000,
+    });
+
+    socketRef.current = socket;
+
+    // Connection Events
+    socket.on('connect', () => {
+      setIsConnected(true);
+    });
+
+    socket.on('disconnect', _reason => {
+      setIsConnected(false);
+    });
+
+    socket.on('connect_error', _error => {
+      setIsConnected(false);
+    });
+
+    socket.on('reconnect', _attemptNumber => {
+      setIsConnected(true);
+    });
+
+    socket.on('reconnect_error', _error => {});
+
+    socket.on('reconnect_failed', () => {
+      setIsConnected(false);
+    });
+
+    // Cleanup al desmontar
+    return () => {
+      socket.disconnect();
+    };
+  }, [url]);
+
+  return {
+    socket: socketRef.current,
+    isConnected,
+  };
+};

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -6,13 +6,12 @@ type UseWebSocketReturn = {
   isConnected: boolean;
 };
 
-export const useWebSocket = (url?: string): UseWebSocketReturn => {
+export const useWebSocket = (): UseWebSocketReturn => {
   const [isConnected, setIsConnected] = useState(false);
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
-    // URL
-    const socketUrl = 'wss://localhost:8443';
+    const socketUrl = import.meta.env.VITE_WS_URL;
 
     // Websocket Connection
     const socket = io(socketUrl, {
@@ -53,7 +52,7 @@ export const useWebSocket = (url?: string): UseWebSocketReturn => {
     return () => {
       socket.disconnect();
     };
-  }, [url]);
+  }, []);
 
   return {
     socket: socketRef.current,

--- a/frontend/src/hooks/useWebSocketContext.ts
+++ b/frontend/src/hooks/useWebSocketContext.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+
+import { WebSocketContext } from './WebSocketContext';
+
+export const useWebSocketContext = () => {
+  const context = useContext(WebSocketContext);
+  if (!context) {
+    throw new Error('Network response was not ok');
+  }
+  return context;
+};

--- a/frontend/src/i18n/en-US/index.ts
+++ b/frontend/src/i18n/en-US/index.ts
@@ -174,6 +174,7 @@ export default {
       'Vulnerability Category Created Successfully!',
     vulnerabilityCategoriesUpdatedOk:
       'Vulnerability Categories Updated Successfully!',
+    reconnectingBackend: 'Reconnecting...',
   },
   err: {
     notDefinedLanguage: 'Not defined for this language',

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,7 @@ import {
 import AuthProvider from './components/AuthProvider';
 import { ErrorPage } from './error-page';
 import { checktoken } from './hooks/useAuth';
+import { WebSocketProvider } from './hooks/WebSocketContext';
 import {
   Audits,
   Data,
@@ -154,7 +155,9 @@ checktoken()
     ).render(
       <React.StrictMode>
         <AuthProvider isSignedIn={result}>
-          <RouterProvider router={router} />
+          <WebSocketProvider>
+            <RouterProvider router={router} />
+          </WebSocketProvider>
         </AuthProvider>
       </React.StrictMode>,
     );

--- a/frontend/src/routes/root.tsx
+++ b/frontend/src/routes/root.tsx
@@ -3,9 +3,13 @@ import { Toaster } from 'sonner';
 
 import Navbar from '../components/navbar/Navbar';
 import ProtectedRoute from '../components/ProtectedRoute';
+import { ConnectionOverlay } from '../components/ui/overlay.tsx';
+import { useWebSocketContext } from '../hooks/useWebSocketContext';
 import { ModelUpdateContainer } from './settings/ModelUpdateContainer';
 
 export const Root = () => {
+  const { isConnected } = useWebSocketContext();
+
   return (
     <>
       <ProtectedRoute>
@@ -23,6 +27,7 @@ export const Root = () => {
           },
         }}
       />
+      <ConnectionOverlay isConnected={isConnected} />
     </>
   );
 };

--- a/frontend/src/routes/root.tsx
+++ b/frontend/src/routes/root.tsx
@@ -8,7 +8,7 @@ import { useWebSocketContext } from '../hooks/useWebSocketContext';
 import { ModelUpdateContainer } from './settings/ModelUpdateContainer';
 
 export const Root = () => {
-  const { isConnected } = useWebSocketContext();
+  const { isConnected, connectionState } = useWebSocketContext();
 
   return (
     <>
@@ -27,7 +27,10 @@ export const Root = () => {
           },
         }}
       />
-      <ConnectionOverlay isConnected={isConnected} />
+      <ConnectionOverlay
+        connectionState={connectionState}
+        isConnected={isConnected}
+      />
     </>
   );
 };


### PR DESCRIPTION
<!--- Proporciona un resumen general de tus cambios en el título -->

## Descripción

<!--- Describe tus cambios en detalle -->
Se realizaron los siguientes cambios:
* Se agregó el paquete "websocket.io-client".
* Se implementó la funcionalidad de que se le notifica al cliente cuando hay una desconexión con el backend.
* Se añade una nueva traducción al i18n (inglés).
* Se añade una nueva URL al frontend/.env.example
* Se le quita un "slash" a la URL HTTPS del frontend/.env.example

Se hace énfasis en que solo se le alerta al usuario cuando este está logueado.

## Motivación y Contexto

<!--- ¿Por qué es necesario este cambio? ¿Qué problema soluciona? -->
<!--- Si soluciona un ticket abierto, por favor, enlaza el ticket aquí. -->

Esta solución ayudará al usuario a tener conocimiento cuando hay problemas con la conexión con el backend, mejorando la experiencia del usuario. Además, se soluciona un pequeño problema que surge con el .env.example actual.

## ¿Cómo ha sido probado?

<!--- Por favor, describe en detalle cómo probaste tus cambios. -->
<!--- Incluye detalles de tu entorno de prueba, y las pruebas que realizaste para -->
<!--- ver cómo tu cambio afecta otras áreas del código, etc. -->

Para probar los cambios se debe:
* Levantar los contenedores (habiendo buildeado previamente)
* Acceder a la aplicación e iniciar sesión
* Detener el contenedor del backend con `docker stop auditforge-backend` y observar la interfaz
* Levantar nuevamente el contenedor con `docker start auditforge-backend` y ver como desaparece el anuncio

Validación adicional:
* Recargar la página y ver que no aparezca el overlay con el mensaje.

## Capturas de pantalla (si es apropiado):

![image](https://github.com/user-attachments/assets/0df2c241-d07a-4ab7-9ce1-f8759c24dcd6)

## Tipos de cambios

<!--- ¿Qué tipos de cambios introduce tu código? Pon una `x` en todas las casillas que apliquen: -->

- [ ] Bugfix (cambio que no interrumpe el funcionamiento y que soluciona un problema)
- [x] New feature (cambio que no interrumpe el funcionamiento y que añade funcionalidad)
- [ ] Breaking change (corrección o funcionalidad que podría causar que la funcionalidad existente cambie)

## Lista de verificación:

<!--- Revisa todos los siguientes puntos, y pon una `x` en todas las casillas que apliquen. -->
<!--- Si no estás seguro sobre alguno de estos puntos, no dudes en preguntar. -->

- [x] Mi código sigue el estilo de código de este proyecto.
- [ ] Mi cambio requiere una modificación en la documentación.
- [ ] He actualizado la documentación en consecuencia.
- [x] Requiere nuevos tests.
